### PR TITLE
Fixed Andie spelling

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -104,7 +104,7 @@
     - Programmer
     - Scout
   personal_description: >-
-    Andi is a super senior majoring in Computer information systems. He enjoys going to the gym to work out. Andi is a 
+    Andy is a super senior majoring in Computer information systems. He enjoys going to the gym to work out. Andi is a 
     former hockey player and still enjoys watching the games. He also enjoys a good party and tailgate.
   professional_description: >-
     As Event Coordinator, Andi plans trips and events and ensures that the members cooperate to get everything ready for 


### PR DESCRIPTION
Now, Ande's name is spelled correctly. ty! 💋